### PR TITLE
Optimise merging of operands in `FilterByExpressionLoop`

### DIFF
--- a/odata-parser.pegjs
+++ b/odata-parser.pegjs
@@ -116,7 +116,7 @@ QueryOptions =
 		'&'
 		@QueryOption
 	)*
-	{ return ParseOptionsObject([option].concat(options)) }
+	{ return ParseOptionsObject([option, ...options]) }
 
 QueryOption =
 		Dollar
@@ -168,7 +168,7 @@ SortOption =
 		','
 		@SortProperty
 	)*
-	{ return { name: '$orderby', value: { properties: [property].concat(properties) } } }
+	{ return { name: '$orderby', value: { properties: [property, ...properties] } } }
 
 SortProperty =
 	property:PropertyPath
@@ -258,8 +258,8 @@ FilterByExpressionLoop =
 
 			rhs:FilterByExpressionLoop
 			{
-				if (Array.isArray(lhs[0]) && op == lhs[0][0]) {
-					lhs[0] = [ op ].concat(lhs[0].slice(1), [rhs]);
+				if (Array.isArray(lhs[0]) && op === lhs[0][0]) {
+					lhs[0].push(rhs);
 				} else {
 					lhs[0] = [ op, lhs[0], rhs ];
 				}
@@ -334,7 +334,7 @@ GroupedPrimitive =
 			@Primitive
 		)*
 	')'
-	{ return [ first ].concat(rest) }
+	{ return [ first, ...rest ] }
 
 
 FilterMethodCallExpression =
@@ -382,7 +382,7 @@ FilterMethodCallExpression =
 				@FilterByExpression
 			)*
 			spaces
-			{ return [ first ].concat(rest) }
+			{ return [ first, ...rest ] }
 		/ '' { return [] }
 		)
 		&{ return args.length === methods[methodName] || (Array.isArray(methods[methodName]) && methods[methodName].includes(args.length)) }
@@ -409,7 +409,7 @@ PropertyPathList =
 		','
 		@PropertyPath
 	)*
-	{ return [path].concat(paths) }
+	{ return [path, ...paths] }
 PropertyPath =
 	resource:ResourceName
 	property:(
@@ -423,7 +423,7 @@ ExpandPropertyPathList =
 		','
 		@ExpandPropertyPath
 	)*
-	{ return [path].concat(paths) }
+	{ return [path, ...paths] }
 ExpandPropertyPath =
 	resource:ResourceName
 	count:(
@@ -437,7 +437,7 @@ ExpandPropertyPath =
 				[&;]
 				@QueryOption
 			)*
-			{ return ParseOptionsObject([option].concat(options)) }
+			{ return ParseOptionsObject([option, ...options]) }
 		/ '' { return {} }
 		)
 		')'
@@ -614,7 +614,7 @@ Duration =
 	&{return day || time}
 	Apostrophe
 	{ return {
-		negative: sign == '-',
+		negative: sign === '-',
 		day: day || undefined,
 		hour: time ? time.hour : undefined,
 		minute: time ? time.minute : undefined,

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "coffee-script": "~1.12.7",
-    "husky": "^2.4.0",
-    "lint-staged": "^8.1.7",
-    "lodash": "^4.16.4",
-    "mocha": "^6.1.4",
+    "husky": "^3.0.5",
+    "lint-staged": "^9.2.5",
+    "lodash": "^4.17.15",
+    "mocha": "^6.2.0",
     "pegjs": "^0.11.0-master.f69239d",
     "require-npm4-to-publish": "^1.0.0",
-    "resin-lint": "^3.0.4",
-    "typescript": "^3.5.1"
+    "resin-lint": "^3.1.0",
+    "typescript": "^3.6.3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This is a huge improvement when merging lots of similar operands - for a test of merging 50,000 operands (`id eq 1 or id eq 2 or ...`) I saw a 15446ms -> 4ms improvement for the change itself and 4374ms -> 607ms for garbage collection which is likely related.  For actual real world performance the difference is likely to be negligible most of the time as operand merging is relatively uncommon but will still help in any cases where it does come into effect

Change-type: patch