### PR TITLE
Ensure boundaries on keywords to fix parsing of eg `note eq 'foobar'`

### DIFF
--- a/odata-parser.pegjs
+++ b/odata-parser.pegjs
@@ -172,10 +172,12 @@ SortOption =
 
 SortProperty =
 	property:PropertyPath
-	spaces
 	order:(
-		'asc'
-	/	'desc'
+		boundary
+		@(
+			'asc'
+		/	'desc'
+		)
 	/	'' { return 'desc' }
 	)
 	{
@@ -285,7 +287,7 @@ FilterByExpressionLoop =
 					lhs[0] = [ op, lhs[0], rhs ];
 				}
 			}
-		/	spaces op:'in' spaces
+		/	boundary op:'in' boundary
 			rhs:GroupedPrimitive
 			{lhs[0] = [ op, lhs[0], rhs ]}
 		)*
@@ -335,12 +337,12 @@ FilterByOperand =
 	/	'div'
 	/	'mul'
 	)
-	spaces
+	boundary
 
 FilterNegateExpression =
 	spaces
 	@'not'
-	spaces
+	boundary
 	@(
 		FilterByValue
 	/	'(' spaces @FilterByExpression spaces ')'
@@ -745,8 +747,16 @@ QuotedTextBind =
 	t:QuotedText
 	{ return Bind('Text', t) }
 
+boundary =
+	(	&'('
+	/	space+
+	)
+
 spaces =
+	space*
+
+space =
 	(	' '
 	/	'%20'
 	/	'+'
-	)*
+	)

--- a/test/filterby.coffee
+++ b/test/filterby.coffee
@@ -349,6 +349,19 @@ module.exports = (test) ->
 		it 'rhr should be $0', ->
 			assert.equal(result.options.$filter[2].bind, 0)
 
+	test "$filter=note eq 'foobar'", ['foobar'], (result) ->
+		it 'A filter should be present', ->
+			assert.notEqual(result.options.$filter, null)
+
+		it "Filter should be an instance of 'eq'", ->
+			assert.equal(result.options.$filter[0], 'eq')
+
+		it 'lhr should be Foo', ->
+			expect(result.options.$filter[1]).to.have.property('name').that.equals('note')
+
+		it 'rhr should be $0', ->
+			assert.equal(result.options.$filter[2].bind, 0)
+
 	methodTest = (args, binds, argsTest) ->
 		(methodName, expectFailure) ->
 			test "$filter=#{methodName}(#{args}) eq 'cake'", binds.concat('cake'), (result, err) ->


### PR DESCRIPTION
Change-type: patch