### PR TITLE
Add support for `/$count` with nested `$filter` in $orderby & $orderby

### DIFF
--- a/odata-parser.pegjs
+++ b/odata-parser.pegjs
@@ -458,11 +458,19 @@ PropertyPath =
 		'/'
 		@PropertyPath
 	)?
-	count:(
+	countOptions:(
 		'/$count'
-		{ return true }
+		optionsObj:(
+			'('
+			@(	Dollar
+				option:FilterByOption
+				{ return CollapseObjectArray([option]) }
+			)
+			')'
+		)?
+		{ return { count: true, options: optionsObj } }
 	)?
-	{ return { name: resource, property, count } }
+	{ return { name: resource, property, ...countOptions } }
 ExpandPropertyPathList =
 	path:ExpandPropertyPath
 	paths:(

--- a/test/filterby.js
+++ b/test/filterby.js
@@ -401,6 +401,53 @@ export default function (test) {
 			assert.equal(result.options.$filter[2].bind, 0));
 	});
 
+	test(
+		'$filter=Products/$count($filter=Price lt 5) ge 1',
+		[5, 1],
+		function (result) {
+			it('A filter should be present', () =>
+				assert.notEqual(result.options.$filter, null));
+
+			it("Filter should be an instance of 'ge'", () =>
+				assert.equal(result.options.$filter[0], 'ge'));
+
+			it('lhr should have the Product count', function () {
+				expect(result.options.$filter[1])
+					.to.have.property('name')
+					.that.equals('Products');
+				expect(result.options.$filter[1])
+					.to.have.property('count')
+					.that.equals(true);
+			});
+
+			it('count options are present on the Product count', () => {
+				assert.notEqual(result.options.$filter[1].options, null);
+				console.log('***', result.options.$filter[1].options);
+			});
+
+			it('A filter should be present on the Product count lhs', () =>
+				assert.notEqual(result.options.$filter[1].options.$filter, null));
+
+			it(`has a Product count filter that is an instance of 'ge'`, () =>
+				assert.equal(result.options.$filter[1].options.$filter[0], 'lt'));
+
+			it(`has an lhs on the Product count filter that is an instance of 'ge'`, () => {
+				expect(result.options.$filter[1].options.$filter[1])
+					.to.have.property('name')
+					.that.equals('Price');
+			});
+
+			it(`has an rhs on the Product count filter that is $0`, () => {
+				expect(result.options.$filter[1].options.$filter[2])
+					.to.have.property('bind')
+					.that.equals(0);
+			});
+
+			it('rhr should be $1', () =>
+				assert.equal(result.options.$filter[2].bind, 1));
+		},
+	);
+
 	test("$filter=note eq 'foobar'", ['foobar'], function (result) {
 		it('A filter should be present', () =>
 			assert.notEqual(result.options.$filter, null));

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import filterby from './filterby';
 
 export default (test) => {
 	describe('$orderby', function () {
@@ -91,5 +92,46 @@ export default (test) => {
 				);
 			});
 		});
+
+		test('$orderby=PropertyOne/$count', function (result) {
+			it('sort options are present on the result', () => {
+				assert.notEqual(result.options.$orderby, null);
+			});
+			it('sort options have property one name specified', () => {
+				assert.equal(result.options.$orderby.properties[0].name, 'PropertyOne');
+			});
+			it('has count defined', () => {
+				assert.equal(result.options.$orderby.properties[0].count, true);
+			});
+		});
+
+		const testFilterOption = function (nestedTest, input, ...optArgs) {
+			const expectation = optArgs.pop();
+			nestedTest(
+				`$orderby=PropertyOne/$count(${input})`,
+				...optArgs,
+				function (result) {
+					it('sort options are present on the result', () => {
+						assert.notEqual(result.options.$orderby, null);
+					});
+					it('sort options have property one name specified', () => {
+						assert.equal(
+							result.options.$orderby.properties[0].name,
+							'PropertyOne',
+						);
+					});
+					it('has count defined', () => {
+						assert.equal(result.options.$orderby.properties[0].count, true);
+					});
+					expectation(result?.options?.$orderby?.properties?.[0]);
+				},
+			);
+		};
+
+		const nestedFilterTest = testFilterOption.bind(null, test);
+		nestedFilterTest.skip = testFilterOption.bind(null, test.skip);
+		nestedFilterTest.only = testFilterOption.bind(null, test.only);
+
+		filterby(nestedFilterTest);
 	});
 };


### PR DESCRIPTION
Afaict this is the OData spec path that allows this
See: https://docs.oasis-open.org/odata/odata/v4.01/os/abnf/odata-abnf-construction-rules.txt
```
orderby     = ( "$orderby" / "orderby" ) EQ orderbyItem *( COMMA orderbyItem )
orderbyItem = commonExpr [ RWS ( "asc" / "desc" ) ]

commonExpr = ( primitiveLiteral
             / arrayOrObject
             / rootExpr
             / firstMemberExpr // <----------
             / functionExpr
             / negateExpr 
             / methodCallExpr 
             / parenExpr 
             / castExpr 
             / isofExpr
             / notExpr
             ) 
             [ addExpr 
             / subExpr 
             / mulExpr 
             / divExpr
             / divbyExpr 
             / modExpr
             ]  
             [ eqExpr 
             / neExpr 
             / ltExpr  
             / leExpr  
             / gtExpr 
             / geExpr 
             / hasExpr 
             / inExpr 
             ]
             [ andExpr 
             / orExpr 
             ] 

firstMemberExpr = memberExpr // <----------
                / inscopeVariableExpr [ "/" memberExpr ]

memberExpr = directMemberExpr // <----------
           / ( optionallyQualifiedEntityTypeName / optionallyQualifiedComplexTypeName ) "/" directMemberExpr

directMemberExpr = propertyPathExpr // <----------
                 / boundFunctionExpr 
                 / annotationExpr

propertyPathExpr = ( entityColNavigationProperty [ collectionNavigationExpr ] 
                   / entityNavigationProperty    [ singleNavigationExpr ] 
                   / complexColProperty          [ complexColPathExpr ]
                   / complexProperty             [ complexPathExpr ] 
                   / primitiveColProperty        [ collectionPathExpr ] // <----------
                   / primitiveProperty           [ primitivePathExpr ]
                   / streamProperty              [ primitivePathExpr ]

primitiveColProperty    = odataIdentifier

collectionPathExpr = count [ OPEN expandCountOption *( SEMI expandCountOption ) CLOSE ] // <-----
                   / filterExpr [ collectionPathExpr ]
                   / "/" anyExpr
                   / "/" allExpr
                   / "/" boundFunctionExpr
                   / "/" annotationExpr

expandCountOption = filter // <-----
                  / search
```


Change-type: minor
See: https://github.com/balena-io/pinejs/issues/577
See: https://jel.ly.fish/thread-f02087f0-7415-42ac-9b54-75fd10fd0c5c
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>