### PR TITLE
Allow ['Null'] inside a bound list

### DIFF
--- a/odata-parser.pegjs
+++ b/odata-parser.pegjs
@@ -347,9 +347,21 @@ GroupedPrimitive =
 		spaces 
 	')'
 	{
-		const indices = bindings.map((binding) => binding.bind);
-		const bindValues = indices.map((index) => binds[index]);
-		binds.splice(indices[0], indices.length);
+		const bindValues = [];
+		let firstNonNullIndex = null;
+		let totalBoundIndexes = 0;
+		for (const binding of bindings) {
+			if (binding?.bind != null) {
+				firstNonNullIndex ??= binding.bind;
+				totalBoundIndexes++;
+				bindValues.push(binds[binding.bind]);
+			} else {
+				bindValues.push(['Null']);
+			}
+		}
+		if (firstNonNullIndex != null) {
+			binds.splice(firstNonNullIndex, totalBoundIndexes);
+		}
 		return Bind('List', bindValues);
 	}
 

--- a/test/filterby.js
+++ b/test/filterby.js
@@ -332,6 +332,46 @@ export default function (test) {
 		},
 	);
 
+	test(
+		'$filter=Price in (1, 2, null, 3, null)',
+		[['List', [['Real', 1], ['Real', 2], ['Null'], ['Real', 3], ['Null']]]],
+		function (result) {
+			it('A filter should be present', () => {
+				assert.notEqual(result.options.$filter, null);
+			});
+
+			it("Filter should be an instance of 'eqany'", () => {
+				assert.equal(result.options.$filter[0], 'eqany');
+			});
+
+			it('lhr should be Price', () => {
+				assert.equal(result.options.$filter[1].name, 'Price');
+			});
+
+			it('rhr should be [ $1 ]', function () {
+				assert.equal(result.options.$filter[2].bind, 0);
+			});
+		},
+	);
+
+	test('$filter=Price in (null)', [['List', [['Null']]]], function (result) {
+		it('A filter should be present', () => {
+			assert.notEqual(result.options.$filter, null);
+		});
+
+		it("Filter should be an instance of 'eqany'", () => {
+			assert.equal(result.options.$filter[0], 'eqany');
+		});
+
+		it('lhr should be Price', () => {
+			assert.equal(result.options.$filter[1].name, 'Price');
+		});
+
+		it('rhr should be [ $1 ]', function () {
+			assert.equal(result.options.$filter[2].bind, 0);
+		});
+	});
+
 	test('$filter=Price add 5 gt 10', [5, 10], function (result) {
 		it('A filter should be present', () => {
 			assert.notEqual(result.options.$filter, null);


### PR DESCRIPTION
Change-type: minor
See: https://balena.fibery.io/search/s9luW#Work/Project/Pinejs-$in-as-a-single-bind-895