### PR TITLE
Support ordering by a Collection Navigation property using a Key notation

### DIFF
--- a/odata-parser.pegjs
+++ b/odata-parser.pegjs
@@ -443,24 +443,38 @@ PropertyPath =
 		name:ResourceName
 		{ return { name } }
 	)
-	(
+	( // singleNavigationExpr
 		'/'
 		property:PropertyPath
 		{ result.property = property }
-	)?
-	(
-		'/$count'
-		optionsObj:(
-			'('
-			@(	Dollar
-				option:FilterByOption
-				{ return CollapseObjectArray([option]) }
+	/	( // collectionNavigationExpr
+			( // collectionPathExpr
+				'/$count'
+				optionsObj:(
+					'('
+					@(	Dollar
+						option:FilterByOption
+						{ return CollapseObjectArray([option]) }
+					)
+					')'
+				)?
+				{ result.count = true; result.options = optionsObj }
 			)
-			')'
-		)?
-		{ result.count = true; result.options = optionsObj }
+		/	( // keyPredicate [ singleNavigationExpr ]
+				(
+					key:Key
+					{ result.key = key }
+				)
+				( // singleNavigationExpr
+					'/'
+					property:PropertyPath
+					{ result.property = property }
+				)?
+			)
+		)
 	)?
 	{ return result }
+
 ExpandPropertyPathList =
 	ExpandPropertyPath|1..,','|
 ExpandPropertyPath =

--- a/test/orderby.js
+++ b/test/orderby.js
@@ -134,5 +134,133 @@ export default (test) => {
 		nestedFilterTest.only = testFilterOption.bind(null, test.only);
 
 		filterby(nestedFilterTest);
+
+		test('$orderby=Products(1) asc', [1], function (result) {
+			it('sort options are present on the result', () => {
+				assert.notEqual(result.options.$orderby, null);
+			});
+			it('sort options have a single property specified', () => {
+				assert.equal(result.options.$orderby.properties.length, 1);
+			});
+			it('sort options property should be as expected', () => {
+				assert.deepStrictEqual(result.options.$orderby.properties, [
+					{
+						name: 'Products',
+						key: { bind: 0 },
+						order: 'asc',
+					},
+				]);
+			});
+		});
+
+		test('$orderby=Products(1)/Quantity asc', [1], function (result) {
+			it('sort options are present on the result', () => {
+				assert.notEqual(result.options.$orderby, null);
+			});
+			it('sort options have a single property specified', () => {
+				assert.equal(result.options.$orderby.properties.length, 1);
+			});
+			it('sort options property should be as expected', () => {
+				assert.deepStrictEqual(result.options.$orderby.properties, [
+					{
+						name: 'Products',
+						key: { bind: 0 },
+						property: { name: 'Quantity' },
+						order: 'asc',
+					},
+				]);
+			});
+		});
+
+		test(
+			`$orderby=Products(partialkey='a')/Quantity asc`,
+			['a'],
+			function (result) {
+				it('sort options are present on the result', () => {
+					assert.notEqual(result.options.$orderby, null);
+				});
+				it('sort options have a single property specified', () => {
+					assert.equal(result.options.$orderby.properties.length, 1);
+				});
+				it('sort options property should be as expected', () => {
+					assert.deepStrictEqual(result.options.$orderby.properties, [
+						{
+							name: 'Products',
+							key: {
+								partialkey: { bind: 0 },
+							},
+							property: { name: 'Quantity' },
+							order: 'asc',
+						},
+					]);
+				});
+			},
+		);
+
+		test('$orderby=Products(a=1,b=2)/Quantity asc', [1, 2], function (result) {
+			it('sort options are present on the result', () => {
+				assert.notEqual(result.options.$orderby, null);
+			});
+			it('sort options have a single property specified', () => {
+				assert.equal(result.options.$orderby.properties.length, 1);
+			});
+			it('sort options property should be as expected', () => {
+				assert.deepStrictEqual(result.options.$orderby.properties, [
+					{
+						name: 'Products',
+						key: {
+							a: { bind: 0 },
+							b: { bind: 1 },
+						},
+						property: { name: 'Quantity' },
+						order: 'asc',
+					},
+				]);
+			});
+		});
+
+		test(`$orderby=Products(1)/Orders/$count asc`, [1], function (result) {
+			it('sort options are present on the result', () => {
+				assert.notEqual(result.options.$orderby, null);
+			});
+			it('sort options have a single property specified', () => {
+				assert.equal(result.options.$orderby.properties.length, 1);
+			});
+			it('sort options property should be as expected', () => {
+				assert.deepStrictEqual(result.options.$orderby.properties, [
+					{
+						name: 'Products',
+						key: { bind: 0 },
+						property: { name: 'Orders', count: true, options: null },
+						order: 'asc',
+					},
+				]);
+			});
+		});
+
+		test(
+			`$orderby=Products(partialkey='a')/Orders/$count asc`,
+			['a'],
+			function (result) {
+				it('sort options are present on the result', () => {
+					assert.notEqual(result.options.$orderby, null);
+				});
+				it('sort options have a single property specified', () => {
+					assert.equal(result.options.$orderby.properties.length, 1);
+				});
+				it('sort options property should be as expected', () => {
+					assert.deepStrictEqual(result.options.$orderby.properties, [
+						{
+							name: 'Products',
+							key: {
+								partialkey: { bind: 0 },
+							},
+							property: { name: 'Orders', count: true, options: null },
+							order: 'asc',
+						},
+					]);
+				});
+			},
+		);
 	});
 };


### PR DESCRIPTION
Change-type: minor
See: https://docs.oasis-open.org/odata/odata/v4.01/os/abnf/odata-abnf-construction-rules.txt
See: https://github.com/balena-io/pinejs/issues/824
See: https://balena.fibery.io/Work/Project/Shape--Build-Add-support-for-sorting-on-user-selected-tag-columns-in-the-server-side-paginated-devic-912